### PR TITLE
Add loading screen for fonts and images

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,12 @@
+.loading {
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+}
+
 .container {
    overflow: hidden;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,11 @@
   align-items: center;
   height: 100vh;
   width: 100vw;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: black;
+  z-index: 1000;
 }
 
 .spinner {
@@ -21,6 +26,31 @@
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+.loading.fade-out {
+  animation: fadeOut 0.5s forwards;
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
+  }
+}
+
+.fade-slide-in {
+  animation: fadeSlideIn 0.5s ease-out;
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,27 @@
 .loading {
   color: white;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   height: 100vh;
   width: 100vw;
+}
+
+.spinner {
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top: 4px solid white;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  animation: spin 1s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .container {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,55 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "./App.css";
 
 function App() {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const fontsReady = (document as any).fonts
+      ? (document as any).fonts.ready
+      : Promise.resolve();
+
+    const imageUrls = [
+      "./kmainwookopya1.png",
+      "./kmdarkerwoo1kopya1.png",
+      "./kmlowestwookopya1.png",
+    ];
+
+    const imagePromises = imageUrls.map(
+      (src) =>
+        new Promise<void>((resolve) => {
+          const img = new Image();
+          img.src = src;
+          if (img.complete) {
+            resolve();
+          } else {
+            img.onload = () => resolve();
+            img.onerror = () => resolve();
+          }
+        })
+    );
+
+    Promise.all([fontsReady, ...imagePromises]).then(() => {
+      setIsLoaded(true);
+    });
+  }, []);
+
+  if (!isLoaded) {
+    return <div className="loading">Loading...</div>;
+  }
+
   return (
-    <div className='container'>
-      <div className='planet'>
-        <div className='animatedwrapper'>
-          <img src='./kmainwookopya1.png' alt='planet 1' />
-          <img src='./kmdarkerwoo1kopya1.png' alt='planet 2' />
-          <img src='./kmlowestwookopya1.png' alt='planet 3' />
+    <div className="container">
+      <div className="planet">
+        <div className="animatedwrapper">
+          <img src="./kmainwookopya1.png" alt="planet 1" />
+          <img src="./kmdarkerwoo1kopya1.png" alt="planet 2" />
+          <img src="./kmlowestwookopya1.png" alt="planet 3" />
         </div>
       </div>
-      <div className='right-circle'></div>
-      <div className='left-circle'></div>
-      <main className='main'>
+      <div className="right-circle"></div>
+      <div className="left-circle"></div>
+      <main className="main">
         <header>
           <h1>
             Join
@@ -27,10 +63,10 @@ function App() {
             analyze your life with a realistic approach, join us!
           </p>
         </header>
-        <a href='https://apps.apple.com/tr/app/hustlecontrol/id1641096356'>
+        <a href="https://apps.apple.com/tr/app/hustlecontrol/id1641096356">
           <img
-            src='https://miro.medium.com/max/600/1*xqT83bMEz92IBYxS9UQNow.png'
-            alt='download from AppStore button'
+            src="https://miro.medium.com/max/600/1*xqT83bMEz92IBYxS9UQNow.png"
+            alt="download from AppStore button"
           />
         </a>
         <footer>COPYRIGHT © 2022 HUSTLECONTROL - ALL RIGHTS RESERVED.</footer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,14 +5,20 @@ function App() {
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    const fontsReady = (document as any).fonts
-      ? (document as any).fonts.ready
-      : Promise.resolve();
+    const fonts = (document as any).fonts;
+    const fontPromises = fonts
+      ? [
+          fonts.ready,
+          fonts.load("1em MyWebFont-bold"),
+          fonts.load("1em MyWebFont-regular"),
+        ]
+      : [];
 
     const imageUrls = [
       "./kmainwookopya1.png",
       "./kmdarkerwoo1kopya1.png",
       "./kmlowestwookopya1.png",
+      "https://miro.medium.com/max/600/1*xqT83bMEz92IBYxS9UQNow.png",
     ];
 
     const imagePromises = imageUrls.map(
@@ -29,13 +35,18 @@ function App() {
         })
     );
 
-    Promise.all([fontsReady, ...imagePromises]).then(() => {
+    Promise.all([...fontPromises, ...imagePromises]).then(() => {
       setIsLoaded(true);
     });
   }, []);
 
   if (!isLoaded) {
-    return <div className="loading">Loading...</div>;
+    return (
+      <div className="loading">
+        <div className="spinner" />
+        <div>Loading...</div>
+      </div>
+    );
   }
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import "./App.css";
 
 function App() {
   const [isLoaded, setIsLoaded] = useState(false);
+  const [showLoading, setShowLoading] = useState(true);
 
   useEffect(() => {
     const fonts = (document as any).fonts;
@@ -40,17 +41,23 @@ function App() {
     });
   }, []);
 
-  if (!isLoaded) {
-    return (
-      <div className="loading">
-        <div className="spinner" />
-        <div>Loading...</div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (isLoaded) {
+      const timer = setTimeout(() => setShowLoading(false), 500);
+      return () => clearTimeout(timer);
+    }
+  }, [isLoaded]);
 
   return (
-    <div className="container">
+    <>
+      {showLoading && (
+        <div className={`loading ${isLoaded ? "fade-out" : ""}`}>
+          <div className="spinner" />
+          <div>Loading...</div>
+        </div>
+      )}
+      {isLoaded && (
+        <div className="container fade-slide-in">
       <div className="planet">
         <div className="animatedwrapper">
           <img src="./kmainwookopya1.png" alt="planet 1" />
@@ -83,6 +90,8 @@ function App() {
         <footer>COPYRIGHT © 2022 HUSTLECONTROL - ALL RIGHTS RESERVED.</footer>
       </main>
     </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add loading state that delays rendering until fonts and images finish loading
- Style loading screen to center text on black background

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e24ffc94c832ea7cce75a6bcbaf79